### PR TITLE
use default preload strategy

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,9 +14,6 @@ const config = {
 		adapter: adapter(),
 		files: {
 			lib: 'src/lib'
-		},
-		output: {
-			preloadStrategy: 'preload-mjs'
 		}
 	}
 };


### PR DESCRIPTION
Firefox and Safari now support `modulepreload`, so there's probably less reason to use something else. A lot of iOS users wouldn't have upgraded to Safari 17 yet, but @gtm-nayan was seeing double requests on Firefox and I'm wondering if this will fix it